### PR TITLE
🩹 hot-patch bma4xx driver at startup to handle 12-bit acceleration sensor values

### DIFF
--- a/boards/t_watch_s3/CMakeLists.txt
+++ b/boards/t_watch_s3/CMakeLists.txt
@@ -1,3 +1,13 @@
+zephyr_library()
+
 zephyr_library_sources(
     t_watch_s3_boot.c
 )
+
+# for access to the bma4xx sensor data format
+# to properly hot-patch the sensor decode api
+zephyr_library_include_directories(
+    ${ZEPHYR_BASE}/drivers/sensor/bosch/bma4xx
+)
+
+

--- a/boards/t_watch_s3/Kconfig.t_watch_s3
+++ b/boards/t_watch_s3/Kconfig.t_watch_s3
@@ -12,11 +12,11 @@ config T_WATCH_S3_BACKLIGHT_BOOT_ON
 	help
 		Enable backlight on boot.
 
-config T_WATCH_S3_RESET_IMU_HACK_PRIORITY
-	int "Workaround for bma4xx oddness"
+config T_WATCH_S3_IMU_HACKS_PRIORITY
+	int "Workarounds for bma4xx oddness"
 	default 55
 	help
-		Priority for resetting the IMU.
+		Priority for workarounds for bma4xx driver oddness.
 
 module = T_WATCH_S3
 module-str = t_watch_s3

--- a/boards/t_watch_s3/t_watch_s3_boot.c
+++ b/boards/t_watch_s3/t_watch_s3_boot.c
@@ -4,6 +4,10 @@
 #include <zephyr/drivers/display.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+
+// exposed privately by this board's CMakeLists.txt
+#include <bma4xx.h>
 
 LOG_MODULE_REGISTER(t_watch_s3, CONFIG_T_WATCH_S3_LOG_LEVEL);
 
@@ -43,8 +47,8 @@ int t_watch_s3_display_on(void)
 // bma4xx sensor driver is initialized.
 #define BMA4XX_REG_CMD (0x7E)
 #define BMA4XX_CMD_SOFT_RESET (0xB6)
-BUILD_ASSERT(CONFIG_T_WATCH_S3_RESET_IMU_HACK_PRIORITY < CONFIG_SENSOR_INIT_PRIORITY);
-BUILD_ASSERT(CONFIG_T_WATCH_S3_RESET_IMU_HACK_PRIORITY > CONFIG_I2C_INIT_PRIORITY);
+BUILD_ASSERT(CONFIG_T_WATCH_S3_IMU_HACKS_PRIORITY < CONFIG_SENSOR_INIT_PRIORITY);
+BUILD_ASSERT(CONFIG_T_WATCH_S3_IMU_HACKS_PRIORITY > CONFIG_I2C_INIT_PRIORITY);
 
 int t_watch_force_reset_imu(void)
 {
@@ -60,5 +64,81 @@ int t_watch_force_reset_imu(void)
     return 0;
 }
 
-SYS_INIT(t_watch_force_reset_imu, POST_KERNEL, CONFIG_T_WATCH_S3_RESET_IMU_HACK_PRIORITY);
+static __typeof__(((struct sensor_decoder_api *)NULL)->decode) original_decode = NULL;
+
+#define INT12_TO_INT16(x) (((x) & 0x800) ? ((x) | 0xF000) : ((x) & 0x7FF))
+
+static int patched_bma4xx_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec ch, uint32_t *fit,
+                                         uint16_t max_count, void *data_out)
+{
+    __ASSERT(original_decode != NULL, "Original decoder is not set");
+    LOG_DBG("Decoding with patched decoder");
+
+    if (*fit != 0)
+    {
+        return 0;
+    }
+
+    if (max_count == 0 || ch.chan_idx != 0)
+    {
+        return -EINVAL;
+    }
+
+    struct bma4xx_encoded_data edata = *(const struct bma4xx_encoded_data *)buffer;
+    switch (ch.chan_type)
+    {
+    case SENSOR_CHAN_ACCEL_X:
+    case SENSOR_CHAN_ACCEL_Y:
+    case SENSOR_CHAN_ACCEL_Z:
+    case SENSOR_CHAN_ACCEL_XYZ:
+        if (!edata.has_accel)
+        {
+            return -ENODATA;
+        }
+
+        edata.accel_xyz[0] = INT12_TO_INT16(edata.accel_xyz[0]);
+        edata.accel_xyz[1] = INT12_TO_INT16(edata.accel_xyz[1]);
+        edata.accel_xyz[2] = INT12_TO_INT16(edata.accel_xyz[2]);
+
+        break;
+    default:
+        break;
+    }
+
+    // the original decoding method assumes that the values in the buffer
+    // are 16-bit. On the bma422, they are actually 12-bit 2's complement.
+    // So, if we see that we are decoding SENSOR_CHAN_ACCEL_XYZ, then we
+    // need to copy and change the buffer.
+    return original_decode((const uint8_t *)&edata, ch, fit, max_count, data_out);
+}
+
+// The current bma4xx driver does not correctly decode the IMU values. It makes
+// an assumption that the values coming off of the device are 16 bit. On the bma422
+// they are actually 12-bit, two's complement. In-tree, this can be fixed by adding
+// a simple conversion from 12 to 16 bit 2's complement in `bma4xx_one_shot_decode`
+// but in the interest in keeping this out-of-tree, we essentially patch in a different
+// decoder that does the right thing.
+//
+// This is definitely undefined behavior (writing to a field of a const struct)
+// but it is actually working (for now, but be weary).
+int bma422_hot_patch_decoder(void)
+{
+    const struct device *dev = DEVICE_DT_GET(DT_ALIAS(accel));
+    const struct sensor_decoder_api *original;
+    if (sensor_get_decoder(dev, &original) != 0)
+    {
+        return -EIO;
+    }
+    original_decode = original->decode;
+
+    // TECHNICALLY, THIS IS UNDEFINED BEHAVIOR: the hot-patching of the original decode
+    // method means we are writing into a struct that was originally declared const.
+    //
+    // Practically, this works, but should be fixed legitimately by fixing the in-tree driver
+    ((struct sensor_decoder_api *)original)->decode = patched_bma4xx_decoder_decode;
+    return 0;
+}
+
+SYS_INIT(t_watch_force_reset_imu, POST_KERNEL, CONFIG_T_WATCH_S3_IMU_HACKS_PRIORITY);
+SYS_INIT(bma422_hot_patch_decoder, PRE_KERNEL_1, 0);
 SYS_INIT(t_watch_s3_display_on, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/boards/t_watch_s3/t_watch_s3_boot.c
+++ b/boards/t_watch_s3/t_watch_s3_boot.c
@@ -106,14 +106,14 @@ static int patched_bma4xx_decoder_decode(const uint8_t *buffer, struct sensor_ch
     }
 
     // the original decoding method assumes that the values in the buffer
-    // are 16-bit. On the bma422, they are actually 12-bit 2's complement.
+    // are 16-bit. On the bma423, they are actually 12-bit 2's complement.
     // So, if we see that we are decoding SENSOR_CHAN_ACCEL_XYZ, then we
     // need to copy and change the buffer.
     return original_decode((const uint8_t *)&edata, ch, fit, max_count, data_out);
 }
 
 // The current bma4xx driver does not correctly decode the IMU values. It makes
-// an assumption that the values coming off of the device are 16 bit. On the bma422
+// an assumption that the values coming off of the device are 16 bit. On the bma423
 // they are actually 12-bit, two's complement. In-tree, this can be fixed by adding
 // a simple conversion from 12 to 16 bit 2's complement in `bma4xx_one_shot_decode`
 // but in the interest in keeping this out-of-tree, we essentially patch in a different
@@ -121,7 +121,7 @@ static int patched_bma4xx_decoder_decode(const uint8_t *buffer, struct sensor_ch
 //
 // This is definitely undefined behavior (writing to a field of a const struct)
 // but it is actually working (for now, but be weary).
-int bma422_hot_patch_decoder(void)
+int bma423_hot_patch_decoder(void)
 {
     const struct device *dev = DEVICE_DT_GET(DT_ALIAS(accel));
     const struct sensor_decoder_api *original;
@@ -140,5 +140,5 @@ int bma422_hot_patch_decoder(void)
 }
 
 SYS_INIT(t_watch_force_reset_imu, POST_KERNEL, CONFIG_T_WATCH_S3_IMU_HACKS_PRIORITY);
-SYS_INIT(bma422_hot_patch_decoder, PRE_KERNEL_1, 0);
+SYS_INIT(bma423_hot_patch_decoder, PRE_KERNEL_1, 0);
 SYS_INIT(t_watch_s3_display_on, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/boards/t_watch_s3/t_watch_s3_procpu.dts
+++ b/boards/t_watch_s3/t_watch_s3_procpu.dts
@@ -120,7 +120,6 @@
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 
-	// external button referred labeled SW7 on schematic
 	pmic: axp2101@34 {
 		status = "okay";
 		compatible = "x-powers,axp2101";

--- a/tests/src/imu.c
+++ b/tests/src/imu.c
@@ -11,46 +11,46 @@ SENSOR_DT_READ_IODEV(imu_iodev, DT_ALIAS(accel),
 
 ZTEST(imu, test_imu)
 {
-    const struct device *imu = DEVICE_DT_GET(DT_ALIAS(accel));
-    zassert_true(device_is_ready(imu), "IMU device is not ready");
+    while (true)
+    {
+        const struct device *imu = DEVICE_DT_GET(DT_ALIAS(accel));
+        zassert_true(device_is_ready(imu), "IMU device is not ready");
 
-    int res = sensor_read_async_mempool(&imu_iodev, &imu_rtio, (void *)imu);
-    zassert_equal(res, 0, "Sensor read failed");
+        int res = sensor_read_async_mempool(&imu_iodev, &imu_rtio, (void *)imu);
+        zassert_equal(res, 0, "Sensor read failed");
 
-    struct rtio_cqe *cqe = rtio_cqe_consume_block(&imu_rtio);
-    zassert_not_null(cqe, "No completion event");
-    zassert_equal(cqe->result, 0, "Sensor read failed");
+        struct rtio_cqe *cqe = rtio_cqe_consume_block(&imu_rtio);
+        zassert_not_null(cqe, "No completion event");
+        zassert_equal(cqe->result, 0, "Sensor read failed");
 
-    uint8_t *buf = NULL;
-    uint32_t buf_len = 0;
-    res = rtio_cqe_get_mempool_buffer(&imu_rtio, cqe, &buf, &buf_len);
-    zassert_equal(res, 0, "Failed to get mempool buffer");
-    zassert_not_null(buf, "Buffer is null");
-    zassert_not_equal(buf_len, 0, "Buffer length is 0");
-    // sanity check - we don't really need the user data
-    // since we only have a single device in the io queue
-    struct device *sensor = cqe->userdata;
-    zassert_equal(sensor, imu, "Sensor mismatch");
+        uint8_t *buf = NULL;
+        uint32_t buf_len = 0;
+        res = rtio_cqe_get_mempool_buffer(&imu_rtio, cqe, &buf, &buf_len);
+        zassert_equal(res, 0, "Failed to get mempool buffer");
+        zassert_not_null(buf, "Buffer is null");
+        zassert_not_equal(buf_len, 0, "Buffer length is 0");
+        // sanity check - we don't really need the user data
+        // since we only have a single device in the io queue
+        struct device *sensor = cqe->userdata;
+        zassert_equal(sensor, imu, "Sensor mismatch");
 
-    // done with the completion event, this does not release the buffer
-    rtio_cqe_release(&imu_rtio, cqe);
+        // done with the completion event, this does not release the buffer
+        rtio_cqe_release(&imu_rtio, cqe);
 
-    const struct sensor_decoder_api *decoder;
-    res = sensor_get_decoder(sensor, &decoder);
-    zassert_equal(res, 0, "Failed to get decoder");
+        const struct sensor_decoder_api *decoder;
+        res = sensor_get_decoder(sensor, &decoder);
+        zassert_equal(res, 0, "Failed to get decoder");
 
-    struct sensor_three_axis_data accel_data;
-    uint32_t fit = 0;
-    res = decoder->decode(buf, (struct sensor_chan_spec){SENSOR_CHAN_ACCEL_XYZ, 0}, &fit, 1, &accel_data);
-    rtio_release_buffer(&imu_rtio, buf, buf_len);
-    zassert_equal(fit, 1, "Fit is not 1");
-    zassert_equal(res, 1, "Decode failed");
+        struct sensor_three_axis_data accel_data;
+        uint32_t fit = 0;
+        const struct sensor_chan_spec ch_spec = {.chan_idx = 0, .chan_type = SENSOR_CHAN_ACCEL_XYZ};
+        res = decoder->decode(buf, ch_spec, &fit, 1, &accel_data);
+        rtio_release_buffer(&imu_rtio, buf, buf_len);
+        zassert_equal(fit, 1, "Fit is not 1");
+        zassert_equal(res, 1, "Decode failed");
 
-    LOG_INF("Accel data: %" PRIsensor_three_axis_data "\n", PRIsensor_three_axis_data_arg(accel_data, 0));
-    zassert_true(accel_data.readings[0].x > 0, "X is not positive");
-    zassert_true(accel_data.readings[0].y > 0, "Y is not positive");
-    zassert_true(accel_data.readings[0].z > 0, "Z is not positive");
-
+        LOG_INF("Accel data: %" PRIsensor_three_axis_data "\n", PRIsensor_three_axis_data_arg(accel_data, 0));
+    }
     ztest_test_pass();
 }
 

--- a/tests/src/imu.c
+++ b/tests/src/imu.c
@@ -2,6 +2,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/version.h>
 LOG_MODULE_DECLARE(bringup, CONFIG_BRINGUP_LOG_LEVEL);
 
 // Define RTIO context with a small pool for our one-shot reads
@@ -9,49 +10,66 @@ RTIO_DEFINE_WITH_MEMPOOL(imu_rtio, 1, 1, 1, 16, sizeof(void *));
 SENSOR_DT_READ_IODEV(imu_iodev, DT_ALIAS(accel),
                      {SENSOR_CHAN_ACCEL_XYZ, 0});
 
+// Available in Zephyr 4.1
+#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 1, 0)
+#warning "Zephyr 4.1 contains the Z_SHIFT_Q31_TO_F32 macro, remove this"
+#else
+#define Z_SHIFT_Q31_TO_F32(src, m) ((float32_t)(((int64_t)src) << m) / (float32_t)(1U << 31))
+#endif
+
 ZTEST(imu, test_imu)
 {
-    while (true)
-    {
-        const struct device *imu = DEVICE_DT_GET(DT_ALIAS(accel));
-        zassert_true(device_is_ready(imu), "IMU device is not ready");
+    LOG_PRINTK("This test assumes the watch is laying screen-up on a flat surface\n");
+    const struct device *imu = DEVICE_DT_GET(DT_ALIAS(accel));
+    zassert_true(device_is_ready(imu), "IMU device is not ready");
 
-        int res = sensor_read_async_mempool(&imu_iodev, &imu_rtio, (void *)imu);
-        zassert_equal(res, 0, "Sensor read failed");
+    int res = sensor_read_async_mempool(&imu_iodev, &imu_rtio, (void *)imu);
+    zassert_equal(res, 0, "Sensor read failed");
 
-        struct rtio_cqe *cqe = rtio_cqe_consume_block(&imu_rtio);
-        zassert_not_null(cqe, "No completion event");
-        zassert_equal(cqe->result, 0, "Sensor read failed");
+    struct rtio_cqe *cqe = rtio_cqe_consume_block(&imu_rtio);
+    zassert_not_null(cqe, "No completion event");
+    zassert_equal(cqe->result, 0, "Sensor read failed");
 
-        uint8_t *buf = NULL;
-        uint32_t buf_len = 0;
-        res = rtio_cqe_get_mempool_buffer(&imu_rtio, cqe, &buf, &buf_len);
-        zassert_equal(res, 0, "Failed to get mempool buffer");
-        zassert_not_null(buf, "Buffer is null");
-        zassert_not_equal(buf_len, 0, "Buffer length is 0");
-        // sanity check - we don't really need the user data
-        // since we only have a single device in the io queue
-        struct device *sensor = cqe->userdata;
-        zassert_equal(sensor, imu, "Sensor mismatch");
+    uint8_t *buf = NULL;
+    uint32_t buf_len = 0;
+    res = rtio_cqe_get_mempool_buffer(&imu_rtio, cqe, &buf, &buf_len);
+    zassert_equal(res, 0, "Failed to get mempool buffer");
+    zassert_not_null(buf, "Buffer is null");
+    zassert_not_equal(buf_len, 0, "Buffer length is 0");
+    // sanity check - we don't really need the user data
+    // since we only have a single device in the io queue
+    struct device *sensor = cqe->userdata;
+    zassert_equal(sensor, imu, "Sensor mismatch");
 
-        // done with the completion event, this does not release the buffer
-        rtio_cqe_release(&imu_rtio, cqe);
+    // done with the completion event, this does not release the buffer
+    rtio_cqe_release(&imu_rtio, cqe);
 
-        const struct sensor_decoder_api *decoder;
-        res = sensor_get_decoder(sensor, &decoder);
-        zassert_equal(res, 0, "Failed to get decoder");
+    const struct sensor_decoder_api *decoder;
+    res = sensor_get_decoder(sensor, &decoder);
+    zassert_equal(res, 0, "Failed to get decoder");
 
-        struct sensor_three_axis_data accel_data;
-        uint32_t fit = 0;
-        const struct sensor_chan_spec ch_spec = {.chan_idx = 0, .chan_type = SENSOR_CHAN_ACCEL_XYZ};
-        res = decoder->decode(buf, ch_spec, &fit, 1, &accel_data);
-        rtio_release_buffer(&imu_rtio, buf, buf_len);
-        zassert_equal(fit, 1, "Fit is not 1");
-        zassert_equal(res, 1, "Decode failed");
+    struct sensor_three_axis_data accel_data;
+    uint32_t fit = 0;
+    const struct sensor_chan_spec ch_spec = {.chan_idx = 0, .chan_type = SENSOR_CHAN_ACCEL_XYZ};
+    res = decoder->decode(buf, ch_spec, &fit, 1, &accel_data);
+    rtio_release_buffer(&imu_rtio, buf, buf_len);
+    zassert_equal(fit, 1, "Fit is not 1");
+    zassert_equal(res, 1, "Decode failed");
 
-        LOG_INF("Accel data: %" PRIsensor_three_axis_data "\n", PRIsensor_three_axis_data_arg(accel_data, 0));
-    }
-    ztest_test_pass();
+    LOG_INF("Accel data: %" PRIsensor_three_axis_data "\n", PRIsensor_three_axis_data_arg(accel_data, 0));
+
+    double x = Z_SHIFT_Q31_TO_F32(accel_data.readings[0].x, accel_data.shift);
+    double y = Z_SHIFT_Q31_TO_F32(accel_data.readings[0].y, accel_data.shift);
+    double z = Z_SHIFT_Q31_TO_F32(accel_data.readings[0].z, accel_data.shift);
+
+    // nominally 0
+    zassert_between_inclusive(x, -0.5, 0.5, "X acceleration is too high");
+
+    // nominally 0
+    zassert_between_inclusive(y, -0.5, 0.5, "Y acceleration is too high");
+
+    // nominally -9.81
+    zassert_between_inclusive(z, -10.3, -9.3, "Z acceleration is too high");
 }
 
 ZTEST_SUITE(imu, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The in-tree bma4xx driver does not handle the 12bit sensor values from the bma423 correctly. This patches the decode method at startup to convert the 12-bit values to 16-bit values. It is technically invoking undefined behavior (via a write to a const struct), so this should be watched with caution.

The real fix is to modify the in-tree bma4xx driver to handle the 12 bit values when the bma423 is used.